### PR TITLE
Update aggregated-data-query.js

### DIFF
--- a/src/js/aggregated-data-query.js
+++ b/src/js/aggregated-data-query.js
@@ -921,8 +921,29 @@ export function getAggregatedDataQuery(suffix, query, term, startYear, endYear, 
           },
           "in_repository": {
             "filter": {
-              "term": {
-                "openalx.open_access.any_repository_has_fulltext": true
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "openalx.open_access.any_repository_has_fulltext": {
+                        "value": true
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "has_repository_copy": {
+                        "value": true
+                      }
+                    }
+                  },
+                  {
+                    "exists": {
+                      "field": "PMCID"
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
               }
             }
           },
@@ -1671,8 +1692,29 @@ export function getAggregatedDataQuery(suffix, query, term, startYear, endYear, 
           },
           "in_repository": {
             "filter": {
-              "term": {
-                "openalx.open_access.any_repository_has_fulltext": true
+              "bool": {
+                "should": [
+                  {
+                    "term": {
+                      "openalx.open_access.any_repository_has_fulltext": {
+                        "value": true
+                      }
+                    }
+                  },
+                  {
+                    "term": {
+                      "has_repository_copy": {
+                        "value": true
+                      }
+                    }
+                  },
+                  {
+                    "exists": {
+                      "field": "PMCID"
+                    }
+                  }
+                ],
+                "minimum_should_match": 1
               }
             }
           },


### PR DESCRIPTION
See oaworks/discussion#3285

Adds PMCID and has_repository_copy in addition to openalx.open_access.any_repository_has_fulltext as options for meeting "in_repository" criteria.

See 

## Before

https://dev.oa.report/bill-and-melinda-gates-foundation/?breakdown=year&start=1980-01-01&end=2025-01-09

![image](https://github.com/user-attachments/assets/b154b496-8df8-459c-9309-57aa1501b54f)


## After

https://deploy-preview-87--dev-oa-report.netlify.app/bill-and-melinda-gates-foundation/?breakdown=year&start=1980-01-01&end=2025-01-09

![image](https://github.com/user-attachments/assets/08a6e69d-eaab-4eaa-9caf-fc24a2192f22)
