### PR TITLE
add supplements.oasupport.status to is_open_access

### DIFF
--- a/src/js/aggregated-data-query.js
+++ b/src/js/aggregated-data-query.js
@@ -70,6 +70,13 @@ function createAggregationTemplate(suffix) {
                   "cc-by", "pd", "cc-0", "public-domain"
                 ]
               }
+            },
+            {
+              terms: {
+                "supplements.oasupport.status.keyword": [
+                  "Successful"
+                ]
+              }
             }
           ],
           minimum_should_match: 1


### PR DESCRIPTION
This is a partial resolution for https://github.com/oaworks/discussion/issues/3493 that provides a good-enough-for-now update to the open_access agg by using OA.Support request status as a fallback for Unpaywall.